### PR TITLE
final polish before jam end

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -92,6 +92,7 @@ jump={
 "deadzone": 0.5,
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777232,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":32,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":87,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
  ]
 }
 test_ink_increment={

--- a/scenes/gameplay/player.tscn
+++ b/scenes/gameplay/player.tscn
@@ -698,6 +698,7 @@ texture = ExtResource( 6 )
 shape = SubResource( 1 )
 
 [node name="Camera2D" type="Camera2D" parent="."]
+current = true
 limit_left = 0
 limit_smoothed = true
 smoothing_enabled = true

--- a/scenes/levels/Level4.tscn
+++ b/scenes/levels/Level4.tscn
@@ -9,7 +9,7 @@
 [ext_resource path="res://assets/sprites/background_cloudA.png" type="Texture" id=7]
 
 [sub_resource type="RectangleShape2D" id=1]
-extents = Vector2( 131.723, 7.31758 )
+extents = Vector2( 171.708, 7.31758 )
 
 [node name="Level2" type="Node2D"]
 
@@ -48,37 +48,37 @@ ink_value = 1
 position = Vector2( 1613, 669 )
 
 [node name="Block6" parent="." instance=ExtResource( 1 )]
-position = Vector2( 1000, 556 )
+position = Vector2( 1000, 566 )
 collision_layer = 3
 collision_mask = 3
 ink_value = 1
 
 [node name="Block7" parent="." instance=ExtResource( 1 )]
-position = Vector2( 997, 360 )
+position = Vector2( 1000, 379 )
 collision_layer = 3
 collision_mask = 3
 ink_value = 1
 
 [node name="Block10" parent="." instance=ExtResource( 1 )]
-position = Vector2( 609, 380 )
+position = Vector2( 544, 379 )
 collision_layer = 3
 collision_mask = 3
 ink_value = 1
 
 [node name="Block11" parent="." instance=ExtResource( 1 )]
-position = Vector2( 603, 549 )
+position = Vector2( 544, 568 )
 collision_layer = 3
 collision_mask = 3
 ink_value = 1
 
 [node name="Block8" parent="." instance=ExtResource( 1 )]
-position = Vector2( 804, 559 )
+position = Vector2( 777, 567 )
 collision_layer = 3
 collision_mask = 3
 ink_value = 1
 
 [node name="Block9" parent="." instance=ExtResource( 1 )]
-position = Vector2( 806, 370 )
+position = Vector2( 775, 379 )
 collision_layer = 3
 collision_mask = 3
 ink_value = 1
@@ -105,7 +105,8 @@ scale = Vector2( 10.7916, 6.47228 )
 script = ExtResource( 4 )
 
 [node name="LavaCollider" type="CollisionShape2D" parent="Lava"]
-position = Vector2( 7.87651, 48.0511 )
+position = Vector2( 32.2474, 48.0511 )
+scale = Vector2( 1, 1 )
 shape = SubResource( 1 )
 
 [node name="Player" parent="." instance=ExtResource( 2 )]

--- a/scenes/levels/Level5.tscn
+++ b/scenes/levels/Level5.tscn
@@ -9,7 +9,7 @@
 [ext_resource path="res://assets/sprites/background_cloudA.png" type="Texture" id=7]
 
 [sub_resource type="RectangleShape2D" id=1]
-extents = Vector2( 131.723, 7.31758 )
+extents = Vector2( 153.152, 7.31758 )
 
 [node name="Level2" type="Node2D"]
 
@@ -45,34 +45,34 @@ collision_mask = 3
 ink_value = 1
 
 [node name="Block2" parent="." instance=ExtResource( 1 )]
-position = Vector2( 1540, 649 )
+position = Vector2( 1547, 660 )
 
 [node name="Block6" parent="." instance=ExtResource( 1 )]
-position = Vector2( 1000, 556 )
+position = Vector2( 1000, 557 )
 collision_layer = 3
 collision_mask = 3
 ink_value = 1
 
 [node name="Block7" parent="." instance=ExtResource( 1 )]
-position = Vector2( 997, 360 )
+position = Vector2( 1002, 381 )
 collision_layer = 3
 collision_mask = 3
 ink_value = 1
 
 [node name="Block10" parent="." instance=ExtResource( 1 )]
-position = Vector2( 609, 380 )
+position = Vector2( 606, 383 )
 collision_layer = 3
 collision_mask = 3
 ink_value = 1
 
 [node name="Block12" parent="." instance=ExtResource( 1 )]
-position = Vector2( 455, 378 )
+position = Vector2( 446, 380 )
 collision_layer = 3
 collision_mask = 3
 ink_value = 1
 
 [node name="Block11" parent="." instance=ExtResource( 1 )]
-position = Vector2( 603, 549 )
+position = Vector2( 606, 559 )
 collision_layer = 3
 collision_mask = 3
 ink_value = 1
@@ -84,7 +84,7 @@ collision_mask = 3
 ink_value = 1
 
 [node name="Block9" parent="." instance=ExtResource( 1 )]
-position = Vector2( 806, 370 )
+position = Vector2( 803, 381 )
 collision_layer = 3
 collision_mask = 3
 ink_value = 1
@@ -111,7 +111,7 @@ scale = Vector2( 10.7916, 6.47228 )
 script = ExtResource( 4 )
 
 [node name="LavaCollider" type="CollisionShape2D" parent="Lava"]
-position = Vector2( 7.87651, 48.0511 )
+position = Vector2( 29.3051, 48.0511 )
 shape = SubResource( 1 )
 
 [node name="Player" parent="." instance=ExtResource( 2 )]

--- a/scenes/levels/Level6.tscn
+++ b/scenes/levels/Level6.tscn
@@ -35,7 +35,7 @@ position = Vector2( 1636, 301 )
 texture = ExtResource( 7 )
 
 [node name="BackgroundTreeLarge" type="Sprite" parent="."]
-position = Vector2( 1299, 105 )
+position = Vector2( 1282, 140 )
 texture = ExtResource( 5 )
 
 [node name="Block" parent="." instance=ExtResource( 1 )]
@@ -45,16 +45,16 @@ collision_mask = 3
 ink_value = 1
 
 [node name="Block2" parent="." instance=ExtResource( 1 )]
-position = Vector2( 1284, 697 )
+position = Vector2( 1286, 704 )
 
 [node name="Block3" parent="." instance=ExtResource( 1 )]
-position = Vector2( 1278, 506 )
+position = Vector2( 1285, 525 )
 
 [node name="Block4" parent="." instance=ExtResource( 1 )]
-position = Vector2( 1279, 291 )
+position = Vector2( 1282, 332 )
 
 [node name="Block5" parent="." instance=ExtResource( 1 )]
-position = Vector2( 1043, 282 )
+position = Vector2( 1044, 327 )
 collision_layer = 3
 collision_mask = 3
 ink_max = 0


### PR DESCRIPTION
- Add W as jump for WASD users
- Camera to follow player because large puzzles can have platforms off screen
- Align block placements for aesthetics
- Extend lava to catch edge platform jumps